### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ OR VS [C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tool
 ### Step 2 (installing from ComfyUI-Manager)
 From [ComfyUI-Manager](https://github.com/ltdrdata/ComfyUI-Manager) search for DeepFuze, and install the node. Restart your ComfyUI, and look at your terminal window to ensure there is no error, or Install from the ComfyUI manager, select "Install Via  GIT URL", and copy past:
 
-    https://github.com/SamKhoze/CompfyUI-DeepFuze.git
+    https://github.com/SamKhoze/ComfyUI-DeepFuze.git
 	
 ![GitInstall](https://github.com/SamKhoze/ComfyUI-DeepFuze/blob/main/images/Git%20Install.jpg)
 


### PR DESCRIPTION
There's a typo in the path to the "Step 2 (installing from ComfyUI-Manager)" section of README.md,

https://github.com/SamKhoze/CompfyUI-DeepFuze.git
should be
https://github.com/SamKhoze/ComfyUI-DeepFuze.git
without the extra letter "p"

